### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ the notebook output.
 First install the package and its dependencies:
 
 ```
-pip install git+https://github.com/altair/altair_data_server.git
+pip install git+https://github.com/altair-viz/altair_data_server.git
 ```
 
 Next import altair and enable the data server:


### PR DESCRIPTION
I had trouble installing and I think it's because the url was incorrect. 