### PR TITLE
Allow setting URL prefix for data_server_proxied

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,32 @@ installed on the jupyter server, and use the proxied data server transformer:
 alt.data_transformers.enable('data_server_proxied')
 ```
 
+The `urlpath` parameter allows you to override the prefix of the proxy URL. By
+default, it's set to `..`, which is currently the only way to make it work for
+arbitrary users when running inside the classic notebook on Binder. If you
+intend your notebooks to be run on Binder but inside JupyterLab, change it to
+`.` instead, which will work provided JupyterLab is in the [default
+workspace](https://jupyterlab.readthedocs.io/en/stable/user/urls.html#managing-workspaces-ui).
+
+```python
+# for notebooks intended for JupyterLab on Binder
+alt.data_transformers.enable('data_server_proxied', urlpath='.')
+```
+
+On a custom JupyterHub instance, a much more robust option is to take advantage
+of JupyterHub's [`/user-redirect`](https://jupyterhub.readthedocs.io/en/stable/reference/urls.html#user-redirect)
+feature (which is not available on Binder):
+
+```python
+# this will work for any JupyterHub user, whether they're using the classic
+# notebook, JupyterLab in the default workspace, or JupyterLab in a named
+# workspace
+alt.data_transformers.enable('data_server_proxied', urlpath='/user-redirect')
+```
+
+If your JupyterHub lives somewhere else than at your server's root, add the
+appropriate prefix to `urlpath`.
+
 ## Example
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/altair-viz/altair_data_server/master?urlpath=lab/tree/AltairDataServer.ipynb)

--- a/altair_data_server/_altair_server.py
+++ b/altair_data_server/_altair_server.py
@@ -56,13 +56,18 @@ class AltairDataServer:
 
 class AltairDataServerProxied(AltairDataServer):
     def __call__(
-        self, data: pd.DataFrame, fmt: str = "json", port: Optional[int] = None
+        self,
+        data: pd.DataFrame,
+        fmt: str = "json",
+        port: Optional[int] = None,
+        urlpath: str = "..",
     ) -> Dict[str, str]:
         result = super().__call__(data, fmt=fmt, port=port)
 
         url_parts = parse.urlparse(result["url"])
+        urlpath = urlpath.rstrip("/")
         # vega defaults to <base>/files, redirect it to <base>/proxy/<port>/<file>
-        result["url"] = f"../proxy/{url_parts.port}{url_parts.path}"
+        result["url"] = f"{urlpath}/proxy/{url_parts.port}{url_parts.path}"
 
         return result
 


### PR DESCRIPTION
Suggests a fix for #40 and documents how to best use `data_server_proxied` with JupyterHub.

If the main use case for `data_server_proxied` is JupyterHub, then I'm thinking maybe `/user-redirect` could be made the default value for `urlpath` -- thoughts?

The patch works fine on a JupyterHub instance I'm running; not tested on Binder or any other such cloud provider (yet).