### PR TITLE
Option 1: Cleaner support for JupyterHub + Binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,32 +53,6 @@ installed on the jupyter server, and use the proxied data server transformer:
 alt.data_transformers.enable('data_server_proxied')
 ```
 
-The `urlpath` parameter allows you to override the prefix of the proxy URL. By
-default, it's set to `..`, which is currently the only way to make it work for
-arbitrary users when running inside the classic notebook on Binder. If you
-intend your notebooks to be run on Binder but inside JupyterLab, change it to
-`.` instead, which will work provided JupyterLab is in the [default
-workspace](https://jupyterlab.readthedocs.io/en/stable/user/urls.html#managing-workspaces-ui).
-
-```python
-# for notebooks intended for JupyterLab on Binder
-alt.data_transformers.enable('data_server_proxied', urlpath='.')
-```
-
-On a custom JupyterHub instance, a much more robust option is to take advantage
-of JupyterHub's [`/user-redirect`](https://jupyterhub.readthedocs.io/en/stable/reference/urls.html#user-redirect)
-feature (which is not available on Binder):
-
-```python
-# this will work for any JupyterHub user, whether they're using the classic
-# notebook, JupyterLab in the default workspace, or JupyterLab in a named
-# workspace
-alt.data_transformers.enable('data_server_proxied', urlpath='/user-redirect')
-```
-
-If your JupyterHub lives somewhere else than at your server's root, add the
-appropriate prefix to `urlpath`.
-
 ## Example
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/altair-viz/altair_data_server/master?urlpath=lab/tree/AltairDataServer.ipynb)


### PR DESCRIPTION
JupyterHub sets a JUPYTERHUB_SERVICE_PREFIX environment variable with
the base URL of the currently running user server. This takes into account
various factors, such as the base URL of the JupyterHub itself, named
servers (if the user has multiple servers running), etc. Binder also
sets the same environment variable, since it uses JupyterHub behind the
scenes.

jupyter-server-proxy proxies arbitrary HTTP requests sent to
$JUPYTERHUB_SERVICE_PREFIX/proxy/<port><path> to localhost:<port><path>
on the server.

This transformer assumes you are running on a JupyterHub (or Binder),
and constructs the appropriate URL for vega to reach the altair server.

You can optionally pass in `urlpath` to override the default.

This change is backwards compatible, since passing urlpath will
still work. The default is just a lot more robust.