### PR TITLE
Option 2: Support jupyterhub/binder in data_server directly

### DIFF
--- a/AltairDataServer.ipynb
+++ b/AltairDataServer.ipynb
@@ -544,16 +544,6 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "*Note: If you are running on a cloud-based hosted notebook like MyBinder, you will have to modify the above slightly, and instead run*\n",
-    "```python\n",
-    "alt.data_transformers.enable('data_server_proxied')\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "MnmkhYaHpzsn"

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ and carry on from there.
 Remotely-hosted notebooks (like JupyterHub or Binder) usually do not allow the end
 user to access arbitrary ports. To enable users to work on that setup, make sure
 [jupyter-server-proxy](https://github.com/jupyterhub/jupyter-server-proxy) is
-installed on the jupyter server, and use the proxied data server transformer:
+installed on the jupyter server, and use the data server transformer as usual:
 
 ```python
-alt.data_transformers.enable('data_server_proxied')
+alt.data_transformers.enable('data_server')
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -53,32 +53,6 @@ installed on the jupyter server, and use the proxied data server transformer:
 alt.data_transformers.enable('data_server_proxied')
 ```
 
-The `urlpath` parameter allows you to override the prefix of the proxy URL. By
-default, it's set to `..`, which is currently the only way to make it work for
-arbitrary users when running inside the classic notebook on Binder. If you
-intend your notebooks to be run on Binder but inside JupyterLab, change it to
-`.` instead, which will work provided JupyterLab is in the [default
-workspace](https://jupyterlab.readthedocs.io/en/stable/user/urls.html#managing-workspaces-ui).
-
-```python
-# for notebooks intended for JupyterLab on Binder
-alt.data_transformers.enable('data_server_proxied', urlpath='.')
-```
-
-On a custom JupyterHub instance, a much more robust option is to take advantage
-of JupyterHub's [`/user-redirect`](https://jupyterhub.readthedocs.io/en/stable/reference/urls.html#user-redirect)
-feature (which is not available on Binder):
-
-```python
-# this will work for any JupyterHub user, whether they're using the classic
-# notebook, JupyterLab in the default workspace, or JupyterLab in a named
-# workspace
-alt.data_transformers.enable('data_server_proxied', urlpath='/user-redirect')
-```
-
-If your JupyterHub lives somewhere else than at your server's root, add the
-appropriate prefix to `urlpath`.
-
 ## Example
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/altair-viz/altair_data_server/master?urlpath=lab/tree/AltairDataServer.ipynb)

--- a/altair_data_server/_altair_server.py
+++ b/altair_data_server/_altair_server.py
@@ -14,7 +14,21 @@ import pandas as pd
 
 
 class AltairDataServer:
-    """Backend server for Altair datasets."""
+    """
+    Backend server for Altair datasets.
+
+    Serves datasets over HTTP dynamically so they do not need to be embedded
+    in the notebook.
+
+    By default, it starts a background server listening on an arbitrary port,
+    and transforms the URLs vega uses for the datasets to fetch from the
+    server. This works when the background server, the jupyter notebook and
+    the user are all on the same machine - the user's local installation.
+
+    On remote installations (like JupyterHub or Binder), the background
+    server can't be directly reached by vega. Instead, the jupyter-server-proxy
+    package is used to proxy user requests to the background server.
+    """
 
     def __init__(self) -> None:
         self._provider: Optional[Provider] = None
@@ -39,7 +53,7 @@ class AltairDataServer:
         return content, _compute_data_hash(content)
 
     def __call__(
-        self, data: pd.DataFrame, fmt: str = "json", port: Optional[int] = None
+        self, data: pd.DataFrame, fmt: str = "json", port: Optional[int] = None, urlprefix: Optional[str] = None
     ) -> Dict[str, str]:
         if self._provider is None:
             self._provider = Provider().start(port=port)
@@ -52,28 +66,41 @@ class AltairDataServer:
                 extension=fmt,
                 headers={"Access-Control-Allow-Origin": "*"},
             )
-        return {"url": self._resources[resource_id].url}
+
+        url = self._resources[resource_id].url
+
+
+        # JupyterHub sets a JUPYTERHUB_SERVICE_PREFIX environment variable with
+        # the base URL of the currently running user server. This takes into account
+        # various factors, such as the base URL of the JupyterHub itself, named
+        # servers (if the user has multiple servers running), etc. Binder also
+        # sets the same environment variable, since it uses JupyterHub behind the
+        # scenes.
+
+        # jupyter-server-proxy proxies arbitrary HTTP requests sent to
+        # $JUPYTERHUB_SERVICE_PREFIX/proxy/<port><path> to localhost:<port><path>
+        # on the server.
+        if urlprefix is None:
+            if 'JUPYTERHUB_SERVICE_PREFIX' in os.environ:
+                urlprefix = os.environ['JUPYTERHUB_SERVICE_PREFIX']
+
+        if urlprefix is not None:
+            url_parts = parse.urlparse(url)
+
+            urlprefix = urlprefix.rstrip("/")
+
+            # vega defaults to <base>/files, redirect it to <base>/proxy/<port>/<file>
+            url = f'{urlprefix}/proxy/{url_parts.port}{url_parts.path}'
+
+
+        return {"url": url}
 
 
 class AltairDataServerProxied(AltairDataServer):
     """
-    Backend server adaptor for use with JupyterHub.
+    Backend server for use with JupyterHub & Binder
 
-    JupyterHub sets a JUPYTERHUB_SERVICE_PREFIX environment variable with
-    the base URL of the currently running user server. This takes into account
-    various factors, such as the base URL of the JupyterHub itself, named
-    servers (if the user has multiple servers running), etc. Binder also
-    sets the same environment variable, since it uses JupyterHub behind the
-    scenes.
-
-    jupyter-server-proxy proxies arbitrary HTTP requests sent to
-    $JUPYTERHUB_SERVICE_PREFIX/proxy/<port><path> to localhost:<port><path>
-    on the server.
-
-    This transformer assumes you are running on a JupyterHub (or Binder),
-    and constructs the appropriate URL for vega to reach the altair server.
-
-    You can optionally pass in `urlpath` to override the default.
+    Deprecated.
     """
     def __call__(
         self,
@@ -82,20 +109,7 @@ class AltairDataServerProxied(AltairDataServer):
         port: Optional[int] = None,
         urlpath: Optional[str] = None,
     ) -> Dict[str, str]:
-        result = super().__call__(data, fmt=fmt, port=port)
-
-        url_parts = parse.urlparse(result["url"])
-        if urlpath is None:
-            if 'JUPYTERHUB_SERVICE_PREFIX' not in os.environ:
-                raise ValueError('Not running in a JupyterHub, urlpath must be explicitly set')
-            urlpath = os.environ['JUPYTERHUB_SERVICE_PREFIX']
-
-        urlpath = urlpath.rstrip("/")
-
-        # vega defaults to <base>/files, redirect it to <base>/proxy/<port>/<file>
-        result["url"] = f"{urlpath}/proxy/{url_parts.port}{url_parts.path}"
-
-        return result
+        return super().__call__(data, fmt=fmt, port=port, urlprefix=urlpath)
 
 
 # Singleton instances


### PR DESCRIPTION
We can reliably automatically detect when we are
running on JupyterHub / Binder, and can 'do the right thing'.
This allows us to use the same code locally as well as remotely.
    
Backwards compatibility is preserved by leaving a stub
for data_server_proxied behind.

Alternative to #46. I much prefer this :)